### PR TITLE
Quick fix for #25

### DIFF
--- a/fabio-src/cbfimage.py
+++ b/fabio-src/cbfimage.py
@@ -204,10 +204,12 @@ class cbfimage(fabioimage):
                 self.cbs = self.cif[CIF_BINARY_BLOCK_KEY]
         binary_data = self.cbs[self.start_binary + len(STARTER):]
         logger.debug("CBS type %s len %s" % (type(self.cbs), len(self.cbs)))
-        ref = numpy.string_(self.header["Content-MD5"])
-        obt = md5sum(binary_data)
-        if ref != obt:
-            logger.error("Checksum of binary data mismatch: expected %s, got %s" % (ref, obt))
+        
+        if self.header.has_key("Content-MD5"):
+                ref = numpy.string_(self.header["Content-MD5"])
+                obt = md5sum(binary_data)
+                if ref != obt:
+                    logger.error("Checksum of binary data mismatch: expected %s, got %s" % (ref, obt))
 
         if self.header["conversions"] == "x-CBF_BYTE_OFFSET":
             self.data = self._readbinary_byte_offset(binary_data).astype(self.bytecode).reshape((self.dim2, self.dim1))


### PR DESCRIPTION
Skips the MD5 check if the checksum is not available in the header.