### PR TITLE
Force to use Qt4

### DIFF
--- a/scripts/fabio_viewer
+++ b/scripts/fabio_viewer
@@ -39,6 +39,7 @@ import numpy
 numpy.seterr(divide='ignore')
 
 import matplotlib
+matplotlib.use("QT4Agg")
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure


### PR DESCRIPTION
Without that, i still have conflict on my Debian 8 distribution.

I guess it tries to provide a simulated Qt4 api from a Qt5 one.

```
valls@marie:~$ fabio_viewer workspace/data/Pilatus1M/Pilatus1M.edf 
Traceback (most recent call last):
  File "/usr/local/bin/fabio_viewer", line 42, in <module>
    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/backend_qt4agg.py", line 18, in <module>
    from .backend_qt5agg import FigureCanvasQTAggBase as _FigureCanvasQTAggBase
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/backend_qt5agg.py", line 15, in <module>
    from .backend_qt5 import QtCore
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/backend_qt5.py", line 27, in <module>
    import matplotlib.backends.qt_editor.figureoptions as figureoptions
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/qt_editor/figureoptions.py", line 17, in <module>
    import matplotlib.backends.qt_editor.formlayout as formlayout
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/qt_editor/formlayout.py", line 58, in <module>
    from matplotlib.backends.qt_compat import QtGui, QtWidgets, QtCore
  File "/usr/local/lib/python2.7/dist-packages/matplotlib/backends/qt_compat.py", line 114, in <module>
    from PyQt5 import QtCore, QtGui, QtWidgets
RuntimeError: the PyQt5.QtCore and PyQt4.QtCore modules both wrap the QObject class
```